### PR TITLE
Parse any as a function within $filter expression

### DIFF
--- a/lib/odata-parser.js
+++ b/lib/odata-parser.js
@@ -105,6 +105,7 @@ module.exports = (function(){
         "otherFunctions2Arg": parse_otherFunctions2Arg,
         "otherFunc2": parse_otherFunc2,
         "cond": parse_cond,
+        "anyFunc": parse_anyFunc,
         "part": parse_part,
         "op": parse_op,
         "unsupported": parse_unsupported,
@@ -4971,18 +4972,90 @@ module.exports = (function(){
         }
         if (result0 !== null) {
           result0 = (function(offset, a, op, b) {
-                                            return {
-                                                type: op,
-                                                left: a,
-                                                right: b
-                                            };
-                                        })(pos0, result0[0], result0[2], result0[4]);
+                                          return {
+                                              type: op,
+                                              left: a,
+                                              right: b
+                                          };
+                                      })(pos0, result0[0], result0[2], result0[4]);
         }
         if (result0 === null) {
           pos = pos0;
         }
         if (result0 === null) {
-          result0 = parse_booleanFunc();
+          result0 = parse_anyFunc();
+          if (result0 === null) {
+            result0 = parse_booleanFunc();
+          }
+        }
+        return result0;
+      }
+      
+      function parse_anyFunc() {
+        var result0, result1, result2, result3;
+        var pos0, pos1, pos2;
+        
+        pos0 = pos;
+        pos1 = pos;
+        pos2 = pos;
+        result0 = parse_identifierPart();
+        if (result0 !== null) {
+          result0 = (function(offset, u) { return { type: "property", name: u }; })(pos2, result0);
+        }
+        if (result0 === null) {
+          pos = pos2;
+        }
+        if (result0 !== null) {
+          if (input.substr(pos, 13) === "/any(f: f eq ") {
+            result1 = "/any(f: f eq ";
+            pos += 13;
+          } else {
+            result1 = null;
+            if (reportFailures === 0) {
+              matchFailed("\"/any(f: f eq \"");
+            }
+          }
+          if (result1 !== null) {
+            result2 = parse_part();
+            if (result2 !== null) {
+              if (input.charCodeAt(pos) === 41) {
+                result3 = ")";
+                pos++;
+              } else {
+                result3 = null;
+                if (reportFailures === 0) {
+                  matchFailed("\")\"");
+                }
+              }
+              if (result3 !== null) {
+                result0 = [result0, result1, result2, result3];
+              } else {
+                result0 = null;
+                pos = pos1;
+              }
+            } else {
+              result0 = null;
+              pos = pos1;
+            }
+          } else {
+            result0 = null;
+            pos = pos1;
+          }
+        } else {
+          result0 = null;
+          pos = pos1;
+        }
+        if (result0 !== null) {
+          result0 = (function(offset, left, right) {
+                                          return {
+                                              type: "any",
+                                              left: left,
+                                              right: right
+                                          };
+                                      })(pos0, result0[0], result0[2]);
+        }
+        if (result0 === null) {
+          pos = pos0;
         }
         return result0;
       }

--- a/test/parser.specs.js
+++ b/test/parser.specs.js
@@ -338,6 +338,35 @@ describe('odata.parser grammar', function () {
       });
     });
 
+    it('should parse $filter with any and a filter expression', function() {
+      var ast = parser.parse("$filter=schools/any(f: f eq 'UNC')");
+
+      assert.equal(ast.$filter.type, "any");
+
+      assert.equal(ast.$filter.left.type, "property");
+      assert.equal(ast.$filter.left.name, "schools");
+      assert.equal(ast.$filter.right.type, "literal");
+      assert.equal(ast.$filter.right.value, "UNC");
+    });
+
+    it('should parse $filter with multiple or-ed anys', function() {
+        var ast = parser.parse("$filter=schools/any(f: f eq 'UNC') or schools/any(f: f eq 'UW')")
+
+        assert.equal(ast.$filter.type, "or");
+
+        assert.equal(ast.$filter.left.type, "any");
+        assert.equal(ast.$filter.left.left.type, "property");
+        assert.equal(ast.$filter.left.left.name, "schools");
+        assert.equal(ast.$filter.left.right.type, "literal");
+        assert.equal(ast.$filter.left.right.value, "UNC");
+
+        assert.equal(ast.$filter.right.type, "any");
+        assert.equal(ast.$filter.right.left.type, "property");
+        assert.equal(ast.$filter.right.left.name, "schools");
+        assert.equal(ast.$filter.right.right.type, "literal");
+        assert.equal(ast.$filter.right.right.value, "UW");
+    });
+
     it('should return an error if invalid value', function() {
 
         var ast = parser.parse("$top=foo");


### PR DESCRIPTION
Parse e.g. `schools/any(f: f eq 'UNC')` into
```
{
  type: 'any',
  left: {
    type: 'property',
    name: 'schools'    
  },
  right: {
    type: 'literal',
    value: 'UNC'
  }
}
```