### PR TITLE
add support for date literal with no quotes

### DIFF
--- a/lib/odata-parser.js
+++ b/lib/odata-parser.js
@@ -50,6 +50,7 @@ module.exports = (function(){
         "binary": parse_binary,
         "boolean": parse_boolean,
         "byte": parse_byte,
+        "date": parse_date,
         "dateTime": parse_dateTime,
         "dateTimeOffset": parse_dateTimeOffset,
         "dateTimeBodyA": parse_dateTimeBodyA,
@@ -332,29 +333,32 @@ module.exports = (function(){
         if (result0 === null) {
           result0 = parse_binary();
           if (result0 === null) {
-            result0 = parse_dateTime();
+            result0 = parse_date();
             if (result0 === null) {
-              result0 = parse_dateTimeOffset();
+              result0 = parse_dateTime();
               if (result0 === null) {
-                result0 = parse_guid();
+                result0 = parse_dateTimeOffset();
                 if (result0 === null) {
-                  result0 = parse_double();
+                  result0 = parse_guid();
                   if (result0 === null) {
-                    result0 = parse_decimal();
+                    result0 = parse_double();
                     if (result0 === null) {
-                      result0 = parse_single();
+                      result0 = parse_decimal();
                       if (result0 === null) {
-                        result0 = parse_int32();
+                        result0 = parse_single();
                         if (result0 === null) {
-                          result0 = parse_int64();
+                          result0 = parse_int32();
                           if (result0 === null) {
-                            result0 = parse_byte();
+                            result0 = parse_int64();
                             if (result0 === null) {
-                              result0 = parse_sbyte();
+                              result0 = parse_byte();
                               if (result0 === null) {
-                                result0 = parse_boolean();
+                                result0 = parse_sbyte();
                                 if (result0 === null) {
-                                  result0 = parse_string();
+                                  result0 = parse_boolean();
+                                  if (result0 === null) {
+                                    result0 = parse_string();
+                                  }
                                 }
                               }
                             }
@@ -593,6 +597,68 @@ module.exports = (function(){
           }
         } else {
           result0 = null;
+          pos = pos0;
+        }
+        return result0;
+      }
+      
+      function parse_date() {
+        var result0, result1, result2, result3, result4;
+        var pos0, pos1;
+        
+        pos0 = pos;
+        pos1 = pos;
+        result0 = parse_year();
+        if (result0 !== null) {
+          if (input.charCodeAt(pos) === 45) {
+            result1 = "-";
+            pos++;
+          } else {
+            result1 = null;
+            if (reportFailures === 0) {
+              matchFailed("\"-\"");
+            }
+          }
+          if (result1 !== null) {
+            result2 = parse_zeroToTwelve();
+            if (result2 !== null) {
+              if (input.charCodeAt(pos) === 45) {
+                result3 = "-";
+                pos++;
+              } else {
+                result3 = null;
+                if (reportFailures === 0) {
+                  matchFailed("\"-\"");
+                }
+              }
+              if (result3 !== null) {
+                result4 = parse_zeroToThirtyOne();
+                if (result4 !== null) {
+                  result0 = [result0, result1, result2, result3, result4];
+                } else {
+                  result0 = null;
+                  pos = pos1;
+                }
+              } else {
+                result0 = null;
+                pos = pos1;
+              }
+            } else {
+              result0 = null;
+              pos = pos1;
+            }
+          } else {
+            result0 = null;
+            pos = pos1;
+          }
+        } else {
+          result0 = null;
+          pos = pos1;
+        }
+        if (result0 !== null) {
+          result0 = (function(offset, y, m, d) { return new Date([y, m, d].join("-")); })(pos0, result0[0], result0[2], result0[4]);
+        }
+        if (result0 === null) {
           pos = pos0;
         }
         return result0;

--- a/src/odata.pegjs
+++ b/src/odata.pegjs
@@ -45,6 +45,7 @@ SQUOTE                      =   "%x27" / "'"
  */
 primitiveLiteral            =   null /
                                 binary /
+                                date /
                                 dateTime /
                                 dateTimeOffset /
                                 guid /
@@ -76,6 +77,8 @@ boolean                     =   "true" { return true; } /
 
 byte                        =   DIGIT DIGIT DIGIT
                                 // numbers in the range from 0 to 257
+                               
+date                        =   y:year "-" m:month "-" d:day { return new Date([y, m, d].join("-")); }
 
 dateTime                    =   "datetime" SQUOTE a:dateTimeBody SQUOTE { return new Date(a); }
 

--- a/test/parser.specs.js
+++ b/test/parser.specs.js
@@ -380,6 +380,11 @@ describe('odata.parser grammar', function () {
         assert.ok(ast.$filter.right.value instanceof Date);
     });
 
+    it('should parse dates in ISO format', function() {
+        var ast = parser.parse("$filter=hireDate ge 2015-01-01");
+        assert.ok(ast.$filter.right.value instanceof Date);
+    });
+
     it('should parse boolean okay', function(){
         var ast = parser.parse('$filter=status eq true');
         assert.equal(ast.$filter.right.value, true);


### PR DESCRIPTION
Parse e.g. `hireDate ge 2015-01-01` into
```
{
  type: 'ge',
  left: {
    type: 'property',
    name: 'hireDate'
  },
  right: {
    type: 'literal',
    value: new Date('2015-01-01')
  }
}
```